### PR TITLE
remove premature addition of Axis components

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,6 @@ const ScatterPlot = props => {
   return (
     <svg width={props.width} height={props.height}>
       <DataCircles {...props} {...scales} />
-      <Axis ax={'x'} {...props} {...scales} />
-      <Axis ax={'y'} {...props} {...scales} />
     </svg>
   );
 };


### PR DESCRIPTION
Just had a chance to work through this updated tutorial and it's excellent!

Just one wee mistake I found, the text adds the two `Axis` components to `ScatterPlot` too early, and the app doesn't work as described until they are added. I've removed the early call to the components altogether, so the reader doesn't know they should be there until they are being added.